### PR TITLE
feat: allow secrets manager option

### DIFF
--- a/src/asm.tf
+++ b/src/asm.tf
@@ -1,7 +1,7 @@
 resource "aws_secretsmanager_secret" "default" {
   count = local.asm_enabled ? 1 : 0
 
-  name        = format("%s/%s", local.ssm_path_prefix, "admin")
+  name        = local.mysql_admin_user_key
   description = format("%s admin creds", module.cluster.id)
 
   # policy                  = "{}"

--- a/src/asm.tf
+++ b/src/asm.tf
@@ -18,7 +18,7 @@ resource "aws_secretsmanager_secret_version" "default" {
   secret_string = jsonencode({
     cluster_domain = local.cluster_domain
     db_host        = module.aurora_mysql.master_host
-    db_port        = local.db_port
+    db_port        = module.aurora_mysql.port
     cluster_name   = module.aurora_mysql.cluster_identifier
     username       = local.mysql_admin_user
     password       = local.mysql_admin_password

--- a/src/asm.tf
+++ b/src/asm.tf
@@ -1,7 +1,7 @@
 resource "aws_secretsmanager_secret" "default" {
   count = local.asm_enabled ? 1 : 0
 
-  name        = local.mysql_admin_user_key
+  name        = local.mysql_admin_password_key
   description = format("%s admin creds", module.cluster.id)
 
   # policy                  = "{}"

--- a/src/asm.tf
+++ b/src/asm.tf
@@ -14,7 +14,7 @@ resource "aws_secretsmanager_secret" "default" {
 resource "aws_secretsmanager_secret_version" "default" {
   count = local.asm_enabled ? 1 : 0
 
-  secret_id     = one(aws_secretsmanager_secret.default[*].id)
+  secret_id = one(aws_secretsmanager_secret.default[*].id)
   secret_string = jsonencode({
     cluster_domain = local.cluster_domain
     db_host        = module.aurora_mysql.master_host

--- a/src/asm.tf
+++ b/src/asm.tf
@@ -1,0 +1,26 @@
+resource "aws_secretsmanager_secret" "default" {
+  count = local.asm_enabled ? 1 : 0
+
+  name        = format("%s/%s", local.ssm_path_prefix, "admin")
+  description = format("%s admin creds", module.cluster.id)
+
+  # policy                  = "{}"
+  # kms_key_id              = null # "aws/secretsmanager"
+  # recovery_window_in_days = null # 30
+
+  tags = module.this.tags
+}
+
+resource "aws_secretsmanager_secret_version" "default" {
+  count = local.asm_enabled ? 1 : 0
+
+  secret_id     = one(aws_secretsmanager_secret.default[*].id)
+  secret_string = jsonencode({
+    cluster_domain = local.cluster_domain
+    db_host        = module.aurora_mysql.master_host
+    db_port        = local.db_port
+    cluster_name   = module.aurora_mysql.cluster_identifier
+    username       = local.mysql_admin_user
+    password       = local.mysql_admin_password
+  })
+}

--- a/src/cluster-regional.tf
+++ b/src/cluster-regional.tf
@@ -1,7 +1,3 @@
-locals {
-  db_port = 3306
-}
-
 module "aurora_mysql" {
   source  = "cloudposse/rds-cluster/aws"
   version = "2.1.0"
@@ -18,7 +14,7 @@ module "aurora_mysql" {
   instance_type       = var.mysql_instance_type
 
   db_name        = local.mysql_db_name
-  db_port        = local.db_port
+  db_port        = var.mysql_db_port
   admin_password = local.mysql_admin_password
   admin_user     = local.mysql_admin_user
 

--- a/src/cluster-regional.tf
+++ b/src/cluster-regional.tf
@@ -1,3 +1,7 @@
+locals {
+  db_port = 3306
+}
+
 module "aurora_mysql" {
   source  = "cloudposse/rds-cluster/aws"
   version = "2.1.0"
@@ -14,7 +18,7 @@ module "aurora_mysql" {
   instance_type       = var.mysql_instance_type
 
   db_name        = local.mysql_db_name
-  db_port        = 3306
+  db_port        = local.db_port
   admin_password = local.mysql_admin_password
   admin_user     = local.mysql_admin_user
 

--- a/src/main.tf
+++ b/src/main.tf
@@ -1,6 +1,9 @@
 locals {
   enabled = module.this.enabled
 
+  asm_enabled = local.enabled && var.secrets_store_type == "ASM"
+  ssm_enabled = local.enabled && var.secrets_store_type == "SSM"
+
   vpc_outputs           = module.vpc.outputs
   dns_delegated_outputs = module.dns-delegated.outputs
   vpc_id                = local.vpc_outputs.vpc_id

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -24,14 +24,19 @@ output "aurora_mysql_master_hostname" {
 }
 
 output "aurora_mysql_master_password" {
-  value       = local.mysql_db_enabled ? "Password for admin user ${module.aurora_mysql.master_username} is stored in SSM at ${local.mysql_admin_password_key}" : null
+  value       = local.mysql_db_enabled ? "Password for admin user ${module.aurora_mysql.master_username} is stored in ${var.secrets_store_type} at ${local.mysql_admin_password_key}" : null
   description = "Location of admin password in SSM"
   sensitive   = true
 }
 
 output "aurora_mysql_master_password_ssm_key" {
-  value       = local.mysql_db_enabled ? local.mysql_admin_password_key : null
+  value       = local.ssm_enabled && local.mysql_db_enabled ? local.mysql_admin_password_key : null
   description = "SSM key for admin password"
+}
+
+output "aurora_mysql_master_password_asm_key" {
+  value       = local.asm_enabled && local.mysql_db_enabled ? local.mysql_admin_password_key : null
+  description = "ASM key for admin password"
 }
 
 output "aurora_mysql_master_username" {

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -25,7 +25,7 @@ output "aurora_mysql_master_hostname" {
 
 output "aurora_mysql_master_password" {
   value       = local.mysql_db_enabled ? "Password for admin user ${module.aurora_mysql.master_username} is stored in ${var.secrets_store_type} at ${local.mysql_admin_password_key}" : null
-  description = "Location of admin password in SSM"
+  description = "Location of admin password"
   sensitive   = true
 }
 

--- a/src/ssm.tf
+++ b/src/ssm.tf
@@ -21,7 +21,7 @@ locals {
     },
     {
       name        = format("%s/%s", local.ssm_path_prefix, "db_port")
-      value       = tostring(local.db_port)
+      value       = module.aurora_mysql.port
       description = "Aurora MySQL DB Master TCP port"
       type        = "String"
       overwrite   = true

--- a/src/ssm.tf
+++ b/src/ssm.tf
@@ -21,7 +21,7 @@ locals {
     },
     {
       name        = format("%s/%s", local.ssm_path_prefix, "db_port")
-      value       = "3306"
+      value       = local.db_port
       description = "Aurora MySQL DB Master TCP port"
       type        = "String"
       overwrite   = true
@@ -74,6 +74,8 @@ data "aws_ssm_parameter" "password" {
 module "parameter_store_write" {
   source  = "cloudposse/ssm-parameter-store/aws"
   version = "0.13.0"
+
+  enabled = local.ssm_enabled
 
   # kms_arn will only be used for SecureString parameters
   kms_arn = module.kms_key_rds.key_arn

--- a/src/ssm.tf
+++ b/src/ssm.tf
@@ -21,7 +21,7 @@ locals {
     },
     {
       name        = format("%s/%s", local.ssm_path_prefix, "db_port")
-      value       = local.db_port
+      value       = tostring(local.db_port)
       description = "Aurora MySQL DB Master TCP port"
       type        = "String"
       overwrite   = true

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -41,6 +41,11 @@ variable "mysql_db_port" {
   type        = number
   description = "Database port"
   default     = 3306
+
+  validation {
+    condition     = var.mysql_db_port >= 1 && var.mysql_db_port <= 65535
+    error_message = "mysql_db_port must be between 1 and 65535."
+  }
 }
 
 variable "mysql_admin_user" {
@@ -238,7 +243,7 @@ variable "secrets_store_type" {
   default     = "SSM"
 
   validation {
-    condition     = var.secrets_store_type == "ASM" || var.secrets_store_type == "SSM"
-    error_message = "secrets_store_type must be either 'ASM' or 'SSM'."
+    condition     = contains(["SSM", "ASM"], var.secrets_store_type)
+    error_message = "secrets_store_type must be one of: SSM, ASM."
   }
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -225,3 +225,14 @@ variable "vpc_component_name" {
   default     = "vpc"
   description = "The name of the VPC component"
 }
+
+variable "secrets_store_type" {
+  type        = string
+  description = "Secret Store type for Datadog API and app keys. Valid values: `SSM`, `ASM`"
+  default     = "SSM"
+
+  validation {
+    condition     = var.secrets_store_type == "ASM" || var.secrets_store_type == "SSM"
+    error_message = "secrets_store_type must be either 'ASM' or 'SSM'."
+  }
+}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -33,8 +33,14 @@ variable "mysql_name" {
 
 variable "mysql_db_name" {
   type        = string
-  description = "Database name (default is not to create a database"
+  description = "Database name (default is not to create a database)"
   default     = ""
+}
+
+variable "mysql_db_port" {
+  type        = number
+  description = "Database port"
+  default     = 3306
 }
 
 variable "mysql_admin_user" {

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -228,7 +228,7 @@ variable "vpc_component_name" {
 
 variable "secrets_store_type" {
   type        = string
-  description = "Secret Store type for Datadog API and app keys. Valid values: `SSM`, `ASM`"
+  description = "Secret Store type to save database credentials. Valid values: `SSM`, `ASM`"
   default     = "SSM"
 
   validation {


### PR DESCRIPTION
## what
- [x] feat: allow secrets manager option
- [x] var to override `db_port`
- [ ] var to override entire ssm param prefix to avoid org-account-env
- [ ] vars to override aws asm secret inputs (policy, key, retention, etc)
- [ ] Testing
- [ ] Address rabbit code review

## why
- Secrets Manager integrates well with aurora
- The implementation of SSM param store in this component will create a new param for each attribute.
- The implementation of ASM will create the secrets in a single JSON string in a single secret due to cost which is $0.40 per secret per month.
- This pr would be repeatable with aurora mysql component
- Should this implementation be in a separate module?

## references
- Closes #21
- https://aws.amazon.com/secrets-manager/pricing/
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version
- https://github.com/cloudposse/terraform-aws-rds-cluster/pull/262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added support for selecting the secrets store type (AWS Secrets Manager or SSM) for saving database credentials.
	- Introduced a configuration option to choose between "ASM" and "SSM" for secrets storage.
	- Outputs now display the location of the admin password based on the selected secrets store type.
	- Added AWS Secrets Manager resources for storing database credentials when ASM is enabled.
- **Enhancements**
	- Secrets and parameter store resources are now conditionally created based on the chosen secrets store type.
	- Database port configuration is now managed through a variable for improved flexibility.
	- Conditional enabling of parameter store write operations based on secrets store type.
- **Bug Fixes**
	- Improved accuracy of output descriptions to reflect the actual secrets store in use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->