### PR TITLE
fix: Remove deprecated Terraform syntax

### DIFF
--- a/src/kms.tf
+++ b/src/kms.tf
@@ -5,7 +5,7 @@ module "kms_key_rds" {
   description             = "KMS key for Aurora MySQL"
   deletion_window_in_days = 10
   enable_key_rotation     = true
-  policy                  = join("", data.aws_iam_policy_document.kms_key_rds.*.json)
+  policy                  = join("", data.aws_iam_policy_document.kms_key_rds[*].json)
 
   context = module.cluster.context
 }
@@ -39,7 +39,7 @@ data "aws_iam_policy_document" "kms_key_rds" {
       type = "AWS"
 
       identifiers = [
-        format("arn:${join("", data.aws_partition.current.*.partition)}:iam::%s:root", join("", data.aws_caller_identity.current.*.account_id))
+        format("arn:${join("", data.aws_partition.current[*].partition)}:iam::%s:root", join("", data.aws_caller_identity.current[*].account_id))
       ]
     }
   }

--- a/src/main.tf
+++ b/src/main.tf
@@ -31,11 +31,11 @@ locals {
 
   # Do not create a DB & DB resources if Read Replication is enabled
   mysql_db_enabled     = local.enabled && !local.is_read_replica
-  mysql_db_name        = length(var.mysql_db_name) > 0 ? var.mysql_db_name : join("", random_pet.mysql_db_name.*.id)
-  mysql_admin_user     = length(var.mysql_admin_user) > 0 ? var.mysql_admin_user : join("", random_pet.mysql_admin_user.*.id)
+  mysql_db_name        = length(var.mysql_db_name) > 0 ? var.mysql_db_name : join("", random_pet.mysql_db_name[*].id)
+  mysql_admin_user     = length(var.mysql_admin_user) > 0 ? var.mysql_admin_user : join("", random_pet.mysql_admin_user[*].id)
   fetch_admin_password = local.mysql_db_enabled && length(var.ssm_password_source) > 0
   mysql_admin_password = local.fetch_admin_password ? data.aws_ssm_parameter.password[0].value : (
-    length(var.mysql_admin_password) > 0 ? var.mysql_admin_password : join("", random_password.mysql_admin_password.*.result)
+    length(var.mysql_admin_password) > 0 ? var.mysql_admin_password : join("", random_password.mysql_admin_password[*].result)
   )
 
   cluster_domain    = trimprefix(module.aurora_mysql.endpoint, "${module.aurora_mysql.cluster_identifier}.cluster-")


### PR DESCRIPTION
## Why

Deprecated HCL syntax triggers linting warnings and will eventually be removed in future Terraform versions. Cleaning these up improves code quality, maintainability, and ensures forward compatibility.

## What

Automated fixes applied via `tflint --fix` with the following rules enabled:

| Rule | Description | Example |
|------|-------------|---------|
| `terraform_deprecated_interpolation` | Remove unnecessary interpolation wrappers | `"${var.foo}"` → `var.foo` |
| `terraform_deprecated_index` | Replace legacy dot-index syntax | `list.0` → `list[0]` |
| `terraform_deprecated_lookup` | Replace deprecated `lookup()` calls | `lookup(map, key)` → `map[key]` |

## References

- [tflint terraform_deprecated_interpolation](https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_deprecated_interpolation.md)
- [tflint terraform_deprecated_index](https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_deprecated_index.md)
- [tflint terraform_deprecated_lookup](https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_deprecated_lookup.md)
- [Terraform: References to Named Values](https://developer.hashicorp.com/terraform/language/expressions/references)